### PR TITLE
Truth tagging

### DIFF
--- a/examples/rotate_to_experimental_coordinates.py
+++ b/examples/rotate_to_experimental_coordinates.py
@@ -1,8 +1,11 @@
 import h5py
-from gampixpy import config, coordinates
+from gampixpy import config, coordinates, readout_objects
 import numpy as np
 
 import torch
+
+N_LABELS_COARSE = readout_objects.N_LABELS_COARSE
+N_LABELS_PIX = readout_objects.N_LABELS_PIX
 
 pixel_dtype = np.dtype([("event id", "u4"),
                         ("hit x", "f4"),
@@ -14,6 +17,8 @@ pixel_dtype = np.dtype([("event id", "u4"),
                         ("tpc z", "f4"),
                         ("hit t", "f4"),
                         ("hit charge", "f4"),
+                        ("attribution", "f4", N_LABELS_COARSE),
+                        ("label", "i4", N_LABELS_COARSE),
                         ],
                        align = True)
 coarse_tile_dtype = np.dtype([("event id", "u4"),
@@ -26,6 +31,8 @@ coarse_tile_dtype = np.dtype([("event id", "u4"),
                               ("tpc z", "f4"),
                               ("hit t", "f4"),
                               ("hit charge", "f4"),
+                              ("attribution", "f4", N_LABELS_PIX),
+                              ("label", "i4", N_LABELS_PIX),
                               ],
                              align = True)
 
@@ -88,6 +95,8 @@ def main(args):
     outfile['pixel_hits']['tpc z'] = pixel_coords[:,2].cpu().numpy()
     outfile['pixel_hits']['hit t'] = infile['pixel_hits']['hit t']
     outfile['pixel_hits']['hit charge'] = infile['pixel_hits']['hit charge']
+    outfile['pixel_hits']['attribution'] = infile['pixel_hits']['attribution']
+    outfile['pixel_hits']['label'] = infile['pixel_hits']['label']
 
     outfile['coarse_hits']['event id'] = infile['coarse_hits']['event id']
     outfile['coarse_hits']['hit x'] = coarse_exp_coords[:,0].cpu().numpy()
@@ -99,6 +108,8 @@ def main(args):
     outfile['coarse_hits']['tpc z'] = coarse_coords[:,2].cpu().numpy()
     outfile['coarse_hits']['hit t'] = infile['coarse_hits']['hit t']
     outfile['coarse_hits']['hit charge'] = infile['coarse_hits']['hit charge']
+    outfile['coarse_hits']['attribution'] = infile['coarse_hits']['attribution']
+    outfile['coarse_hits']['label'] = infile['coarse_hits']['label']
 
     outfile.close()
     

--- a/gampixpy/coordinates.py
+++ b/gampixpy/coordinates.py
@@ -153,6 +153,7 @@ class CoordinateManager:
         tpc_coords = torch.empty((0,3))
         tpc_time = torch.empty((0,))
         tpc_charge = torch.empty((0,))
+        tpc_label = torch.empty((0,))
         for volume_name, volume_dict in self.detector_config['drift_volumes'].items():
             # choose an arbitrary corner.  Which one doesn't matter, but it should be
             # between 0 and 7 (a rectangular prism has 8 vertices)
@@ -178,6 +179,7 @@ class CoordinateManager:
             tpc_index_subset = self.volume_to_index[volume_name]*torch.ones(anode_disp.shape[0])
             tpc_time_subset = track.raw_track['time'][keep_mask]
             tpc_charge_subset = track.raw_track['charge'][keep_mask]
+            tpc_label_subset = track.raw_track['label'][keep_mask]
             
             tpc_index = torch.concatenate([tpc_index,
                                            tpc_index_subset])
@@ -187,11 +189,14 @@ class CoordinateManager:
                                           tpc_time_subset])
             tpc_charge = torch.concatenate([tpc_charge,
                                             tpc_charge_subset])
+            tpc_label = torch.concatenate([tpc_label,
+                                           tpc_label_subset])
 
         track.tpc_track = {'TPC_index': tpc_index,
                            'position': tpc_coords,
                            'time': tpc_time,
                            'charge': tpc_charge,
+                           'label': tpc_label,
                            }
 
     def to_tpc_indices(self, coords):

--- a/gampixpy/detector.py
+++ b/gampixpy/detector.py
@@ -562,6 +562,14 @@ class GAMPixModel (ReadoutModel):
     readout_config : ReadoutConfig object
         Config object containing specifications for tile and pixel size, gaps,
         threshold, noise, etc.
+    physics_config : PhysicsConfig object
+        Config object containing physics parameters for liquid Argon.
+    detector_config : DetectorConfig object
+        Config object containing specifications for TPC volume position and
+        orientation.
+    coordinate_manager : CoordinateManager object
+        Coordinate manager defined by the provided physics_config.  This is a
+        helper for transforming to and from TPC-specific coordinate systems.
     clock_start_time : float
         timestamp of the earliest arriving charge bundle.  This serves as the
         first clock tick of the event readout.
@@ -746,6 +754,14 @@ class LArPixModel (ReadoutModel):
     clock_start_time : float
         timestamp of the earliest arriving charge bundle.  This serves as the
         first clock tick of the event readout.
+    physics_config : PhysicsConfig object
+        Config object containing physics parameters for liquid Argon.
+    detector_config : DetectorConfig object
+        Config object containing specifications for TPC volume position and
+        orientation.
+    coordinate_manager : CoordinateManager object
+        Coordinate manager defined by the provided physics_config.  This is a
+        helper for transforming to and from TPC-specific coordinate systems.
     coarse_tile_hits : array-like[CoarseTileHit]
         Array of coarse tile hits populated by tile_hit_finding method
     fine_pixel_hits : array-like[CoarseTileHit]

--- a/gampixpy/input_parsing.py
+++ b/gampixpy/input_parsing.py
@@ -22,19 +22,24 @@ meta_dtype =  np.dtype([("event id", "u4"),
 class InputParser:
     """
     InputParser(input_filename,
+                position_offset = [0, 0, 0],
                 sequential_sampling = True,
-                physics_config = default_physics_params)
+                physics_config = default_physics_params,
+                detector_config = default_detector_params)
 
     Parent class for more specialized input parsers.
 
     Attributes
     ----------
+    input_filename : str or os.path-like
+        Path to the input data on disk.
     physics_config : PhysicsConfig object
         Physics configuration.  Some early physics processes are handled
         by the input parser (for now!), such as charge/light yield
         calculation.
-    input_filename : str or os.path-like
-        Path to the input data on disk.
+    detector_config : DetectorConfig object
+        Config object containing specifications for TPC volume position and
+        orientation.
     sampling_order : array-like
         Array describing the order for iterating through the input indices.
     """
@@ -68,22 +73,27 @@ class InputParser:
 class SegmentParser (InputParser):
     """
     SegmentParser(input_filename,
-                sequential_sampling = True,
-                physics_config = default_physics_params)
+                  position_offset = [0, 0, 0],
+                  sequential_sampling = True,
+                  physics_config = default_physics_params,
+                  detector_config = default_detector_params)
 
     Parent class for segment-based input parsers.  This class defines
     methods for point sampline along segment-like inputs and recombination.
 
     Attributes
     ----------
-    physics_config : PhysicsConfig object
-        Physics configuration.  Some early physics processes are handled
-        by the input parser (for now!), such as charge/light yield
-        calculation.
     input_filename : str or os.path-like
         Path to the input data on disk.
     sampling_order : array-like
         Array describing the order for iterating through the input indices.
+    physics_config : PhysicsConfig object
+        Physics configuration.  Some early physics processes are handled
+        by the input parser (for now!), such as charge/light yield
+        calculation.
+    detector_config : DetectorConfig object
+        Config object containing specifications for TPC volume position and
+        orientation.
     
     """
     def do_recombination(self, dE, dx, dEdx, mode = 'birks', **kwargs):
@@ -228,14 +238,17 @@ class RooTrackerParser (SegmentParser):
 
     Attributes
     ----------
-    physics_config : PhysicsConfig object
-        Physics configuration.  Some early physics processes are handled
-        by the input parser (for now!), such as charge/light yield
-        calculation.
     input_filename : str or os.path-like
         Path to the input data on disk.
     sampling_order : array-like
         Array describing the order for iterating through the input indices.
+    physics_config : PhysicsConfig object
+        Physics configuration.  Some early physics processes are handled
+        by the input parser (for now!), such as charge/light yield
+        calculation.
+    detector_config : DetectorConfig object
+        Config object containing specifications for TPC volume position and
+        orientation.
     
     """
     def _open_file_handle(self, **kwargs):

--- a/gampixpy/readout_objects.py
+++ b/gampixpy/readout_objects.py
@@ -1,5 +1,8 @@
 import numpy as np
 
+N_LABELS_COARSE = 3
+N_LABELS_PIX = 3
+
 coarse_tile_dtype = np.dtype([("event id", "u4"),
                               ("tile tpc", "u4"),
                               ("tile x", "f4"),
@@ -7,6 +10,8 @@ coarse_tile_dtype = np.dtype([("event id", "u4"),
                               ("hit z", "f4"),
                               ("hit t", "f4"),
                               ("hit charge", "f4"),
+                              ("attribution", "f4", N_LABELS_COARSE),
+                              ("label", "i4", N_LABELS_COARSE),
                               ],
                              align = True)
 pixel_dtype = np.dtype([("event id", "u4"),
@@ -16,6 +21,8 @@ pixel_dtype = np.dtype([("event id", "u4"),
                         ("hit z", "f4"),
                         ("hit t", "f4"),
                         ("hit charge", "f4"),
+                        ("attribution", "f4", N_LABELS_PIX),
+                        ("label", "i4", N_LABELS_PIX),
                         ],
                        align = True)
 
@@ -50,12 +57,23 @@ class PixelSample:
                  pixel_pos,
                  hit_timestamp,
                  hit_depth,
-                 hit_measurement):
+                 hit_measurement,
+                 attribution,
+                 labels):
         self.pixel_tpc = pixel_tpc
         self.pixel_pos = pixel_pos
         self.hit_timestamp = hit_timestamp
         self.hit_depth = hit_depth
         self.hit_measurement = hit_measurement
+
+        # save the N_LABELS_PIX highest contributing labels
+        # if tere are fewer than N_LABELS_PIX, label is -1
+        # and fraction is 0
+        self.attribution = np.zeros(N_LABELS_PIX)
+        self.labels = -1*np.ones(N_LABELS_PIX)
+        for i, sorted_ind in enumerate(np.argsort(attribution)[::-1]):
+            self.attribution[i] = attribution[sorted_ind]
+            self.labels[i] = labels[sorted_ind]
 
 class CoarseGridSample:
     """
@@ -63,7 +81,9 @@ class CoarseGridSample:
                      coarse_cell_pos,
                      hit_timestamp,
                      hit_depth,
-                     hit_measurement)
+                     hit_measurement,
+                     attribution,
+                     labels)
 
     Data container class for coarse tile samples.
 
@@ -88,9 +108,20 @@ class CoarseGridSample:
                  coarse_cell_pos,
                  measurement_time,
                  measurement_depth,
-                 coarse_cell_measurement):
+                 coarse_cell_measurement,
+                 attribution,
+                 labels):
         self.coarse_cell_tpc = coarse_cell_tpc
         self.coarse_cell_pos = coarse_cell_pos
         self.coarse_measurement_time = measurement_time
         self.coarse_measurement_depth = measurement_depth
         self.coarse_cell_measurement = coarse_cell_measurement
+
+        # save the N_LABELS_COARSE highest contributing labels
+        # if tere are fewer than N_LABELS_COARSE, label is -1
+        # and fraction is 0
+        self.attribution = np.zeros(N_LABELS_COARSE)
+        self.labels = -1*np.ones(N_LABELS_COARSE)
+        for i, sorted_ind in enumerate(np.argsort(attribution)[::-1]):
+            self.attribution[i] = attribution[sorted_ind]
+            self.labels[i] = labels[sorted_ind]

--- a/gampixpy/readout_objects.py
+++ b/gampixpy/readout_objects.py
@@ -118,10 +118,10 @@ class CoarseGridSample:
         self.coarse_cell_measurement = coarse_cell_measurement
 
         # save the N_LABELS_COARSE highest contributing labels
-        # if tere are fewer than N_LABELS_COARSE, label is -1
+        # if tere are fewer than N_LABELS_COARSE, label is 0
         # and fraction is 0
         self.attribution = np.zeros(N_LABELS_COARSE)
-        self.labels = -1*np.ones(N_LABELS_COARSE)
+        self.labels = np.zeros(N_LABELS_COARSE)
         for i, sorted_ind in enumerate(np.argsort(attribution)[::-1]):
             self.attribution[i] = attribution[sorted_ind]
             self.labels[i] = labels[sorted_ind]

--- a/gampixpy/readout_objects.py
+++ b/gampixpy/readout_objects.py
@@ -67,10 +67,10 @@ class PixelSample:
         self.hit_measurement = hit_measurement
 
         # save the N_LABELS_PIX highest contributing labels
-        # if tere are fewer than N_LABELS_PIX, label is -1
+        # if tere are fewer than N_LABELS_PIX, label is 0
         # and fraction is 0
         self.attribution = np.zeros(N_LABELS_PIX)
-        self.labels = -1*np.ones(N_LABELS_PIX)
+        self.labels = np.zeros(N_LABELS_PIX)
         for i, sorted_ind in enumerate(np.argsort(attribution)[::-1]):
             self.attribution[i] = attribution[sorted_ind]
             self.labels[i] = labels[sorted_ind]

--- a/gampixpy/readout_objects.py
+++ b/gampixpy/readout_objects.py
@@ -72,8 +72,9 @@ class PixelSample:
         self.attribution = np.zeros(N_LABELS_PIX)
         self.labels = np.zeros(N_LABELS_PIX)
         for i, sorted_ind in enumerate(np.argsort(attribution)[::-1]):
-            self.attribution[i] = attribution[sorted_ind]
-            self.labels[i] = labels[sorted_ind]
+            if i < N_LABELS_PIX:
+                self.attribution[i] = attribution[sorted_ind]
+                self.labels[i] = labels[sorted_ind]
 
 class CoarseGridSample:
     """
@@ -123,5 +124,6 @@ class CoarseGridSample:
         self.attribution = np.zeros(N_LABELS_COARSE)
         self.labels = np.zeros(N_LABELS_COARSE)
         for i, sorted_ind in enumerate(np.argsort(attribution)[::-1]):
-            self.attribution[i] = attribution[sorted_ind]
-            self.labels[i] = labels[sorted_ind]
+            if i < N_LABELS_COARSE:
+                self.attribution[i] = attribution[sorted_ind]
+                self.labels[i] = labels[sorted_ind]

--- a/gampixpy/tracks.py
+++ b/gampixpy/tracks.py
@@ -14,8 +14,9 @@ class Track:
 
     raw_track : dict
         Dict containing sample position vectors (key: 'position'),
-        sample ionization time (key 'time'), and sample charge 
-        values (key 'charge').  All are array-like.
+        sample ionization time (key 'time'), sample charge values
+        (key 'charge'), and sample labels (key 'label').  All are
+        array-like.
     drifted_track : dict
         Dict containing sample position 3-vectors ('position'), sample
         arrival times ('time') and charge after attenuation ('charge').
@@ -30,10 +31,16 @@ class Track:
     CoarseTileSample : Data class for tile hits.
     
     """
-    def __init__(self, sample_position, sample_time, sample_charge):
+    def __init__(self,
+                 sample_position,
+                 sample_time,
+                 sample_charge,
+                 sample_labels,
+                 ):
         self.raw_track = {'position': sample_position,
                           'time': sample_time,
-                          'charge': sample_charge}
+                          'charge': sample_charge,
+                          'label': sample_labels}
 
         self.tpc_track = {}
         self.drifted_track = {}
@@ -66,7 +73,9 @@ class Track:
                                               hit.coarse_cell_pos[1],
                                               hit.coarse_measurement_depth,
                                               hit.coarse_measurement_time,
-                                              hit.coarse_cell_measurement)
+                                              hit.coarse_cell_measurement,
+                                              hit.attribution,
+                                              hit.labels)
                                              for hit in self.coarse_tiles_samples],
                                             dtype = coarse_tile_dtype)
         pixel_sample_array = np.array([(0,
@@ -75,7 +84,9 @@ class Track:
                                         hit.pixel_pos[1],
                                         hit.hit_depth,
                                         hit.hit_timestamp,
-                                        hit.hit_measurement)
+                                        hit.hit_measurement,
+                                        hit.attribution,
+                                        hit.labels)
                                        for hit in self.pixel_samples],
                                       dtype = pixel_dtype)
 


### PR DESCRIPTION
Adds truth tagging to output data products.  Options for tagging now are pdg_id, segment_id, and vertex_id.  

The interface for selecting these needs some work (should probably be specified in readout config)

This closes the truth tracking issue.